### PR TITLE
FPET-814 task name change for approving order

### DIFF
--- a/src/main/resources/wa-task-configuration-privatelaw-prlapps.dmn
+++ b/src/main/resources/wa-task-configuration-privatelaw-prlapps.dmn
@@ -1022,7 +1022,7 @@ caseData.allegationsOfHarmYesNo="Yes") then 3000 else 5000</text>
           <text>"description"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1pnixna">
-          <text>"[Review and Approve Solicitor Order](/cases/case-details/${[CASE_REFERENCE]}/trigger/editAndApproveAnOrder/editAndApproveAnOrder1)"</text>
+          <text>"[Review and Approve Legal rep Order](/cases/case-details/${[CASE_REFERENCE]}/trigger/editAndApproveAnOrder/editAndApproveAnOrder1)"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1z0pkcv">
           <text></text>

--- a/src/main/resources/wa-task-initiation-privatelaw-prlapps.dmn
+++ b/src/main/resources/wa-task-initiation-privatelaw-prlapps.dmn
@@ -919,7 +919,7 @@
           <text>"reviewSolicitorOrderProvided"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_05wsi4k">
-          <text>"Review and Approve Solicitor Order"</text>
+          <text>"Review and Approve Legal rep Order"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_19zz5f9">
           <text></text>

--- a/src/test/java/uk/gov/hmcts/reform/prl/taskconfiguration/dmn/CamundaTaskInitiationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/taskconfiguration/dmn/CamundaTaskInitiationTest.java
@@ -246,7 +246,7 @@ class CamundaTaskInitiationTest extends DmnDecisionTableBaseUnitTest {
                 singletonList(
                     Map.of(
                         "taskId", "reviewSolicitorOrderProvided",
-                        "name", "Review and Approve Solicitor Order",
+                        "name", "Review and Approve Legal rep Order",
                         "processCategories", "reviewSolicitorOrderByJudge"
                     )
                 )


### PR DESCRIPTION



### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/FPET-814 


### Change description ###
when the case is in 'Draft' status, Change the name of WA task from Review and approve solicitor draft order to Review and approve Legal rep draft order - so that the right set of users have access to the right set of events when a case is in Draft status


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
