### PR TITLE
Revert "SNI-6634"

### DIFF
--- a/src/main/resources/wa-task-completion-privatelaw-prlapps.dmn
+++ b/src/main/resources/wa-task-completion-privatelaw-prlapps.dmn
@@ -671,7 +671,7 @@
       </rule>
       <rule id="DecisionRule_05kvogz">
         <inputEntry id="UnaryTests_0cb5u2c">
-          <text>"manageOrders","serviceOfApplication","createBundle","adminEditAndApproveAnOrder","returnApplication","sendOrReplyToMessages","adminRemoveLegalRepresentativeC100","adminRemoveLegalRepresentativeFL401","c100ManageFlags","fl401ManageFlags","statementOfService","editAndApproveAnOrder"</text>
+          <text>"manageOrders","serviceOfApplication","createBundle","adminEditAndApproveAnOrder","returnApplication","sendOrReplyToMessages","adminRemoveLegalRepresentativeC100","adminRemoveLegalRepresentativeFL401","c100ManageFlags","fl401ManageFlags","statementOfService"</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_1o5rfjh">
           <text></text>

--- a/src/test/java/uk/gov/hmcts/reform/prl/taskconfiguration/dmn/CamundaTaskCompletionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/taskconfiguration/dmn/CamundaTaskCompletionTest.java
@@ -218,8 +218,7 @@ class CamundaTaskCompletionTest extends DmnDecisionTableBaseUnitTest {
                     Map.of(
                         "taskType", "reviewAdminOrderByManager",
                         "completionMode", "Auto"
-                    ),
-                    Map.of()
+                    )
                 )
             ),
             Arguments.of(


### PR DESCRIPTION
Reverts hmcts/prl-wa-task-configuration#170

Revert "SNI-6634" [SNI-6634](https://tools.hmcts.net/jira/browse/SNI-6634)
SNI-6634 was about enabling the 'edit and approve an draft order' event without a WA task in order to fix INC5650580.
The user was not able to proceed with the case since the WA task was automatically closed without any event execution and in order to fix the scenario, we enabled the above said event.
Post our fix, the case was progressed ahead and now we can revert the changes and bring it to default settings.