### PR TITLE
Revert "SNI-6671"

### DIFF
--- a/src/main/resources/wa-task-completion-privatelaw-prlapps.dmn
+++ b/src/main/resources/wa-task-completion-privatelaw-prlapps.dmn
@@ -671,7 +671,7 @@
       </rule>
       <rule id="DecisionRule_05kvogz">
         <inputEntry id="UnaryTests_0cb5u2c">
-          <text>"manageOrders","serviceOfApplication","createBundle","adminEditAndApproveAnOrder","returnApplication","sendOrReplyToMessages","adminRemoveLegalRepresentativeC100","adminRemoveLegalRepresentativeFL401","c100ManageFlags","fl401ManageFlags","statementOfService","sendToGateKeeper","caseNumber"</text>
+          <text>"manageOrders","serviceOfApplication","createBundle","adminEditAndApproveAnOrder","returnApplication","sendOrReplyToMessages","adminRemoveLegalRepresentativeC100","adminRemoveLegalRepresentativeFL401","c100ManageFlags","fl401ManageFlags","statementOfService"</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_1o5rfjh">
           <text></text>

--- a/src/test/java/uk/gov/hmcts/reform/prl/taskconfiguration/dmn/CamundaTaskCompletionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/taskconfiguration/dmn/CamundaTaskCompletionTest.java
@@ -163,8 +163,7 @@ class CamundaTaskCompletionTest extends DmnDecisionTableBaseUnitTest {
                     Map.of(
                         "taskType", "addCaseNumberResubmitted",
                         "completionMode", "Auto"
-                    ),
-                    Map.of()
+                    )
                 )
             ),
             Arguments.of(
@@ -176,8 +175,7 @@ class CamundaTaskCompletionTest extends DmnDecisionTableBaseUnitTest {
                     ), Map.of(
                         "taskType", "sendToGateKeeperResubmittedC100",
                         "completionMode", "Auto"
-                    ),
-                    Map.of()
+                    )
                 )
             ),
             Arguments.of(


### PR DESCRIPTION
Reverts hmcts/prl-wa-task-configuration#173

Disabled Send to Gatekeeper and Add a Case number event without a task in since the fix was released for INC5653423 and the user was able to proceed with the case progression and now we can disable back the events.