### PR TITLE
PRL-6781 - Unbind FL401 list on notice & list without notice events from tasks

### DIFF
--- a/src/main/resources/wa-task-completion-privatelaw-prlapps.dmn
+++ b/src/main/resources/wa-task-completion-privatelaw-prlapps.dmn
@@ -737,7 +737,7 @@
       </rule>
       <rule id="DecisionRule_05kvogz">
         <inputEntry id="UnaryTests_0cb5u2c">
-          <text>"manageOrders","serviceOfApplication","createBundle","adminEditAndApproveAnOrder","returnApplication","sendOrReplyToMessages","adminRemoveLegalRepresentativeC100","adminRemoveLegalRepresentativeFL401","c100ManageFlags","fl401ManageFlags","statementOfService","serviceOfDocuments"</text>
+          <text>"manageOrders","serviceOfApplication","createBundle","adminEditAndApproveAnOrder","returnApplication","sendOrReplyToMessages","adminRemoveLegalRepresentativeC100","adminRemoveLegalRepresentativeFL401","c100ManageFlags","fl401ManageFlags","statementOfService","serviceOfDocuments","fl401ListOnNotice","listWithoutNotice"</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_1o5rfjh">
           <text></text>

--- a/src/test/java/uk/gov/hmcts/reform/prl/taskconfiguration/dmn/CamundaTaskCompletionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/taskconfiguration/dmn/CamundaTaskCompletionTest.java
@@ -351,7 +351,8 @@ class CamundaTaskCompletionTest extends DmnDecisionTableBaseUnitTest {
                     Map.of(
                         "taskType", "directionOnIssueResubmitted",
                         "completionMode", "Auto"
-                    )
+                    ),
+                    Map.of()
                 )
             ),
             Arguments.of(
@@ -364,7 +365,8 @@ class CamundaTaskCompletionTest extends DmnDecisionTableBaseUnitTest {
                     Map.of(
                         "taskType", "directionOnIssueResubmitted",
                         "completionMode", "Auto"
-                    )
+                    ),
+                    Map.of()
                 )
             ),
             Arguments.of(


### PR DESCRIPTION

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRL-6781


### Change description ###
Unbind FL401 list on notice & list without notice events from tasks so that these events can be executed without task.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
