### PR TITLE
Added the missing roleCategory for "hearingListed"

### DIFF
--- a/src/main/resources/wa-task-configuration-privatelaw-prlapps.dmn
+++ b/src/main/resources/wa-task-configuration-privatelaw-prlapps.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" id="wa-configuration-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.29.0">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" id="wa-configuration-definition" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.12.0">
   <decision id="wa-task-configuration-privatelaw-prlapps" name="Private Law Task configuration DMN">
     <informationRequirement id="InformationRequirement_1iac9a2">
       <requiredDecision href="#Decision_11ew6tt" />
@@ -1008,6 +1008,26 @@ taskAttributes. taskType else if(taskType != null) then taskType else null</text
           <text></text>
         </outputEntry>
       </rule>
+      <rule id="DecisionRule_1k9rnps">
+        <inputEntry id="UnaryTests_08tk17j">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0wr2o5i">
+          <text>"hearingListed"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1yyd2vc">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1hj393l">
+          <text>"roleCategory"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_07mrw5l">
+          <text>"ADMIN"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0l8pe9u">
+          <text>"true"</text>
+        </outputEntry>
+      </rule>
       <rule id="DecisionRule_17ypugq">
         <inputEntry id="UnaryTests_1i0b00r">
           <text></text>
@@ -1890,7 +1910,7 @@ taskAttributes. taskType else if(taskType != null) then taskType else null</text
           <text></text>
         </outputEntry>
       </rule>
-        <rule id="DecisionRule_1etrohr">
+      <rule id="DecisionRule_1etrohr">
         <inputEntry id="UnaryTests_0h7unfd">
           <text></text>
         </inputEntry>

--- a/src/test/java/uk/gov/hmcts/reform/prl/taskconfiguration/dmn/CamundaTaskConfigurationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/taskconfiguration/dmn/CamundaTaskConfigurationTest.java
@@ -1206,7 +1206,8 @@ class CamundaTaskConfigurationTest extends DmnDecisionTableBaseUnitTest {
 
         assertTrue(workTypeResultList.contains(Map.of(
             "name", "roleCategory",
-            "value", "ADMIN"
+            "value", "ADMIN",
+            "canReconfigure", true
         )));
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/prl/taskconfiguration/dmn/CamundaTaskConfigurationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/taskconfiguration/dmn/CamundaTaskConfigurationTest.java
@@ -34,7 +34,7 @@ class CamundaTaskConfigurationTest extends DmnDecisionTableBaseUnitTest {
         DmnDecisionTableImpl logic = (DmnDecisionTableImpl) decision.getDecisionLogic();
         assertThat(logic.getInputs().size(), is(3));
         assertThat(logic.getOutputs().size(), is(3));
-        assertThat(logic.getRules().size(), is(94));
+        assertThat(logic.getRules().size(), is(95));
     }
 
 
@@ -1157,6 +1157,34 @@ class CamundaTaskConfigurationTest extends DmnDecisionTableBaseUnitTest {
         "replyToMessageForCourtAdminFL401","reviewRaRequestsC100","reviewInactiveRaRequestsC100",
         "listWithoutNoticeHearingC100","listOnNoticeHearingFL401","reviewAdditionalApplication",
         "reviewLangAndSmReq","confidentialCheckDocuments","checkAndReServeDocuments"
+    })
+    void when_given_task_type_then_return_roleCategoryForValueAdmin_and_validate_description(
+        String taskType) {
+        VariableMap inputVariables = new VariableMapImpl();
+        inputVariables.putValue(
+            "taskAttributes",
+            Map.of("taskId", "1234",
+                   "taskType", taskType,
+                   "name", "FirstName"
+            )
+        );
+        DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
+
+        List<Map<String, Object>> workTypeResultList = dmnDecisionTableResult.getResultList().stream()
+            .filter((r) -> r.containsValue("roleCategory"))
+            .toList();
+
+        assertThat(workTypeResultList.size(), is(1));
+
+        assertTrue(workTypeResultList.contains(Map.of(
+            "name", "roleCategory",
+            "value", "ADMIN"
+        )));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+       "hearingListed"
     })
     void when_given_task_type_then_return_roleCategoryForValueAdmin_and_validate_description(
         String taskType) {

--- a/src/test/java/uk/gov/hmcts/reform/prl/taskconfiguration/dmn/CamundaTaskConfigurationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/taskconfiguration/dmn/CamundaTaskConfigurationTest.java
@@ -1184,7 +1184,7 @@ class CamundaTaskConfigurationTest extends DmnDecisionTableBaseUnitTest {
 
     @ParameterizedTest
     @CsvSource({
-       "hearingListed"
+        "hearingListed"
     })
     void when_given_task_type_hearingListed_then_return_roleCategoryForValueAdmin_and_validate_description(
         String taskType) {

--- a/src/test/java/uk/gov/hmcts/reform/prl/taskconfiguration/dmn/CamundaTaskConfigurationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/taskconfiguration/dmn/CamundaTaskConfigurationTest.java
@@ -1186,7 +1186,7 @@ class CamundaTaskConfigurationTest extends DmnDecisionTableBaseUnitTest {
     @CsvSource({
        "hearingListed"
     })
-    void when_given_task_type_then_return_roleCategoryForValueAdmin_and_validate_description(
+    void when_given_task_type_hearingListed_then_return_roleCategoryForValueAdmin_and_validate_description(
         String taskType) {
         VariableMap inputVariables = new VariableMapImpl();
         inputVariables.putValue(


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FPET-1252

### Change description ###

"hearingListed" task does not has roleCategory defined in the configuration DMN ,It has to be added with "Can reconfigure" as "true" to handle the missing roleCategory in the existing tasks.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
