### PR TITLE
Update dependencies to fix CVE-2024-38820, CVE-2025-24813 & CVE-2024-38286

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -244,7 +244,7 @@ def versions = [
   camunda         : '7.18.0',
   pitest          : '1.16.0',
   sonarPitest     : '0.5',
-  tomcat          : '9.0.83',
+  tomcat          : '9.0.104',
   log4j           : '2.17.1'
 
 ]

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,4 +1,53 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+  <suppress>
+    <notes><![CDATA[
+   file name: spring-aop-5.3.33.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-aop@.*$</packageUrl>
+    <cve>CVE-2024-38820</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: spring-beans-5.3.33.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-beans@.*$</packageUrl>
+    <cve>CVE-2024-38820</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: spring-context-5.3.33.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-context@.*$</packageUrl>
+    <cve>CVE-2024-38820</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: spring-core-5.3.33.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-core@.*$</packageUrl>
+    <cve>CVE-2024-38820</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: spring-expression-5.3.33.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-expression@.*$</packageUrl>
+    <cve>CVE-2024-38820</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: spring-jcl-5.3.33.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-jcl@.*$</packageUrl>
+    <cve>CVE-2024-38820</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: spring-webmvc-5.3.33.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-webmvc@.*$</packageUrl>
+    <cve>CVE-2024-38820</cve>
+  </suppress>
 </suppressions>
 


### PR DESCRIPTION
### Change description ###

* update tomcat version to non vulnerable version to fix CVE-2025-24813 & CVE-2024-38286
* add spring vulns to suppression list - we don't have any usage of the spring DataBinder class, which contains the vulnerability, if we wanted to update spring it would need to be to a major version which would be a larger change

See vulnerable dependencies identified below:
<img width="1440" alt="Screenshot 2025-04-22 at 12 17 11" src="https://github.com/user-attachments/assets/8d477c85-77af-4a3d-8360-607affc44468" />

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
