### PR TITLE
FPVTL-1105: revert decoupling for fl401AddCaseNumber and fl401SendToGatekeeper

### DIFF
--- a/src/main/resources/wa-task-completion-privatelaw-prlapps.dmn
+++ b/src/main/resources/wa-task-completion-privatelaw-prlapps.dmn
@@ -814,7 +814,7 @@
       </rule>
       <rule id="DecisionRule_0ttgpjf">
         <inputEntry id="UnaryTests_1v7zhnr">
-          <text>"manageOrders","serviceOfApplication","createBundle","adminEditAndApproveAnOrder","returnApplication","sendOrReplyToMessages","adminRemoveLegalRepresentativeC100","adminRemoveLegalRepresentativeFL401","c100ManageFlags","fl401ManageFlags","statementOfService","serviceOfDocuments","fl401ListOnNotice","listOnNotice","listWithoutNotice","c100listWithoutNotice","caseNumber","fl401SendToGateKeeper","fl401AddCaseNumber"</text>
+          <text>"manageOrders","serviceOfApplication","createBundle","adminEditAndApproveAnOrder","returnApplication","sendOrReplyToMessages","adminRemoveLegalRepresentativeC100","adminRemoveLegalRepresentativeFL401","c100ManageFlags","fl401ManageFlags","statementOfService","serviceOfDocuments","fl401ListOnNotice","listOnNotice","listWithoutNotice","c100listWithoutNotice","caseNumber"</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_1g8kdqq">
           <text></text>

--- a/src/test/java/uk/gov/hmcts/reform/prl/taskconfiguration/dmn/CamundaTaskCompletionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/taskconfiguration/dmn/CamundaTaskCompletionTest.java
@@ -150,8 +150,7 @@ class CamundaTaskCompletionTest extends DmnDecisionTableBaseUnitTest {
                     Map.of(
                         "taskType", "checkApplicationResubmittedFL401",
                         "completionMode", "Auto"
-                    ),
-                    Map.of()
+                    )
                 )
             ),
             Arguments.of(
@@ -189,8 +188,7 @@ class CamundaTaskCompletionTest extends DmnDecisionTableBaseUnitTest {
                     ), Map.of(
                         "taskType", "sendToGateKeeperResubmittedFL401",
                         "completionMode", "Auto"
-                    ),
-                    Map.of()
+                    )
                 )
             ),
             Arguments.of(


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/FPVTL-1105


### Change description ###
Revert decoupling for fl401AddCaseNumber and fl401SendToGatekeeper


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
