### PR TITLE
FPVTL-2408-2409 Updating request order tasks

### DIFF
--- a/src/main/resources/wa-task-initiation-privatelaw-prlapps.dmn
+++ b/src/main/resources/wa-task-initiation-privatelaw-prlapps.dmn
@@ -3935,7 +3935,7 @@ and additionalData.Data.isHearingTaskNeeded != null) then
         </outputEntry>
         <outputEntry id="LiteralExpression_0yhayu9">
           <text>{
-"delayUntil":(date and time(date(now()) + duration("P5D")))
+"delayUntil":(date and time(date(now()) + duration("P1D")))
 }</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_13cxgrq">

--- a/src/main/resources/wa-task-initiation-privatelaw-prlapps.dmn
+++ b/src/main/resources/wa-task-initiation-privatelaw-prlapps.dmn
@@ -3843,11 +3843,11 @@ and additionalData.Data.isHearingTaskNeeded != null) then
           <text>"requestSolicitorOrderC100"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1175d8m">
-          <text>"Request Solicitor Order"</text>
+          <text>"Request Order"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_140ejeb">
           <text>{
-"delayUntil":(date and time(date(now()) + duration("P5D")))
+"delayUntil":(date and time(date(now()) + duration("P3D")))
 }</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0oqqgxq">
@@ -3931,7 +3931,7 @@ and additionalData.Data.isHearingTaskNeeded != null) then
           <text>"requestSolicitorOrderFL401"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1k6zapd">
-          <text>"Request Solicitor Order"</text>
+          <text>"Request Order"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0yhayu9">
           <text>{

--- a/src/test/java/uk/gov/hmcts/reform/prl/taskconfiguration/dmn/CamundaTaskInitiationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/taskconfiguration/dmn/CamundaTaskInitiationTest.java
@@ -1768,6 +1768,22 @@ class CamundaTaskInitiationTest extends DmnDecisionTableBaseUnitTest {
                         "requestSolicitorOrder"
                     )
                 )
+            ),
+            Arguments.of(
+                "enableRequestSolicitorOrderTask",
+                "DECISION_OUTCOME",
+                mapAdditionalData("{\n"
+                                      + "   \"Data\":{\n"
+                                      + "      \"caseTypeOfApplication\":\"" + "FL401" + "\"\n"
+                                      + "   }"
+                                      + "}"),
+                singletonList(
+                    mapWithDelayUntil(
+                        "requestSolicitorOrderFL401",
+                        "Request Solicitor Order",
+                        "requestSolicitorOrder"
+                    )
+                )
             )
         );
     }

--- a/src/test/java/uk/gov/hmcts/reform/prl/taskconfiguration/dmn/CamundaTaskInitiationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/taskconfiguration/dmn/CamundaTaskInitiationTest.java
@@ -1752,6 +1752,22 @@ class CamundaTaskInitiationTest extends DmnDecisionTableBaseUnitTest {
                         "taskId", "replyToMessageForJudiciary"
                     )
                 )
+            ),
+            Arguments.of(
+                "enableRequestSolicitorOrderTask",
+                "DECISION_OUTCOME",
+                mapAdditionalData("{\n"
+                                      + "   \"Data\":{\n"
+                                      + "      \"caseTypeOfApplication\":\"" + "C100" + "\"\n"
+                                      + "   }"
+                                      + "}"),
+                singletonList(
+                    mapWithDelayUntil(
+                        "requestSolicitorOrderC100",
+                        "Request Solicitor Order",
+                        "requestSolicitorOrder"
+                    )
+                )
             )
         );
     }
@@ -1771,6 +1787,18 @@ class CamundaTaskInitiationTest extends DmnDecisionTableBaseUnitTest {
         DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
 
         assertThat(dmnDecisionTableResult.getResultList(), is(expectation));
+    }
+
+    private static Map<String, Object> mapWithDelayUntil(String taskId, String name,
+                                                            String processCategories) {
+        Map<String, Object> delayUntilMap = new HashMap<>();
+        delayUntilMap.put("delayUntil", null);
+        Map<String, Object> result = new HashMap<>();
+        result.put("taskId", taskId);
+        result.put("name", name);
+        result.put("processCategories", processCategories);
+        result.put("delayUntil", delayUntilMap);
+        return result;
     }
 
     private static Map<String, Object> mapAdditionalData(String additionalData) {

--- a/src/test/java/uk/gov/hmcts/reform/prl/taskconfiguration/dmn/CamundaTaskInitiationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/prl/taskconfiguration/dmn/CamundaTaskInitiationTest.java
@@ -1764,7 +1764,7 @@ class CamundaTaskInitiationTest extends DmnDecisionTableBaseUnitTest {
                 singletonList(
                     mapWithDelayUntil(
                         "requestSolicitorOrderC100",
-                        "Request Solicitor Order",
+                        "Request Order",
                         "requestSolicitorOrder"
                     )
                 )
@@ -1780,7 +1780,7 @@ class CamundaTaskInitiationTest extends DmnDecisionTableBaseUnitTest {
                 singletonList(
                     mapWithDelayUntil(
                         "requestSolicitorOrderFL401",
-                        "Request Solicitor Order",
+                        "Request Order",
                         "requestSolicitorOrder"
                     )
                 )


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/FPVTL-2408
https://tools.hmcts.net/jira/browse/FPVTL-2409


Update “Request Solicitor Order” Task Timing for Domestic Abuse (DA) Cases (Generate 1 Day After Hearing)
Update “Request Solicitor Order” Task Timing for Child Arrangements (CA) Cases (Generate 3 Days After Hearing)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
