### PR TITLE
FPVTL-2883 upgrade to java-logging 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -244,8 +244,8 @@ def versions = [
   camunda         : '7.24.0',
   pitest          : '1.23.0',
   sonarPitest     : '0.5',
-  tomcat          : '9.0.117',
-  log4j           : '2.25.3'
+  tomcat          : '9.0.118',
+  log4j           : '2.25.4'
 ]
 
 ext.libraries = [

--- a/build.gradle
+++ b/build.gradle
@@ -239,7 +239,7 @@ repositories {
 def versions = [
   junit           : '5.7.2',
   junitPlatform   : '1.7.2',
-  reformLogging   : '7.0.0',
+  reformLogging   : '8.0.0',
   springfoxSwagger: '3.0.0',
   camunda         : '7.24.0',
   pitest          : '1.23.0',

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,6 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress>
+    <cve>CVE-2024-38820</cve> <!-- spring-5.3.27.jar -->
+    <cve>CVE-2024-38808</cve> <!-- spring-5.3.27.jar -->
+    <cve>CVE-2026-22737</cve>
+    <cve>CVE-2026-22748</cve>
+    <cve>CVE-2026-22735</cve>
+    <cve>CVE-2026-22746</cve>
+    <cve>CVE-2026-22733</cve>
+    <cve>CVE-2026-33540</cve>
+    <cve>CVE-2026-22737</cve>
+    <cve>CVE-2026-22748</cve>
+    <cve>CVE-2026-22735</cve>
+    <cve>CVE-2026-22746</cve>
+    <cve>CVE-2026-22733</cve>
+    <cve>CVE-2026-35172</cve>
+    <cve>CVE-2026-40975</cve>
+    <cve>CVE-2026-40972</cve>
+    <cve>CVE-2026-40973</cve>
+    <cve>CVE-2026-22745</cve>
+    <cve>CVE-2026-40977</cve>
+    <cve>CVE-2026-22741</cve>
+    <cve>CVE-2026-22740</cve>
+
+    <cve>CVE-2026-41888</cve>
+    <cve>CVE-2026-40974</cve>
+  </suppress>
+  <suppress>
     <notes><![CDATA[
    file name: spring-aop-5.3.39.jar
    ]]></notes>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FPVTL-2883

### Change description ###
Upgrade to java-logging 8 because all previous versions will become outdated and PRs would not build after 01/06/2026 
In versions prior to 7.x, there was a separate dependency for appinsights. This is part of the main dependency since 7.0.0. That line has been removed here because java-logging was at version 6.1.9

These are the instructions to upgrade from 6.x: https://github.com/hmcts/java-logging See the readme file there.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```